### PR TITLE
fix: verifyCaptchaCodeLogic error

### DIFF
--- a/app/user/internal/logic/registerLogic.go
+++ b/app/user/internal/logic/registerLogic.go
@@ -289,6 +289,7 @@ func (l *RegisterLogic) Register(in *pb.RegisterReq) (*pb.RegisterResp, error) {
 				Code:      *in.CaptchaCode,
 				Scene:     "register",
 				Delete:    true,
+				CommonReq: in.CommonReq,
 			})
 		})
 		if err != nil {


### PR DESCRIPTION
runtime error: invalid memory address or nil pointer dereference